### PR TITLE
feat: are.na image carousel

### DIFF
--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -64,6 +64,12 @@ export default config({
                 channelSlug: fields.text({ label: "Channel slug" }),
               },
             }),
+            ArenaCarousel: block({
+              label: "Arena Carousel",
+              schema: {
+                channelSlug: fields.text({ label: "Channel slug" }),
+              },
+            }),
             Code: block({
               label: "Code Block",
               schema: {
@@ -96,16 +102,6 @@ export default config({
                 channelSlug: fields.text({ label: "Video ID" }),
               },
             }),
-            Model3D: block({
-              label: "3D Model Viewer",
-              schema: {
-                modelFile: fields.file({
-                  label: "3D Model File",
-                  directory: "public/models",
-                  publicPath: "/models",
-                }),
-              },
-            }),
             Carousel: block({
               label: "Image Carousel",
               schema: {
@@ -118,7 +114,7 @@ export default config({
                   {
                     label: "Carousel Images",
                     itemLabel: (props) => props.value?.filename || "Image",
-                  },
+                  }
                 ),
               },
             }),
@@ -178,20 +174,16 @@ export default config({
                 channelSlug: fields.text({ label: "Channel slug" }),
               },
             }),
-            InViewImagesGrid: block({
-              label: "Arena grid",
+            ArenaCarousel: block({
+              label: "Arena Carousel",
               schema: {
                 channelSlug: fields.text({ label: "Channel slug" }),
               },
             }),
-            Model3D: block({
-              label: "3D Model Viewer",
+            InViewImagesGrid: block({
+              label: "Arena grid",
               schema: {
-                modelFile: fields.file({
-                  label: "3D Model File",
-                  directory: "public/models",
-                  publicPath: "/models",
-                }),
+                channelSlug: fields.text({ label: "Channel slug" }),
               },
             }),
             YoutubeEmbed: block({
@@ -212,7 +204,7 @@ export default config({
                   {
                     label: "Carousel Images",
                     itemLabel: (props) => props.value?.filename || "Image",
-                  },
+                  }
                 ),
               },
             }),

--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -114,7 +114,7 @@ export default config({
                   {
                     label: "Carousel Images",
                     itemLabel: (props) => props.value?.filename || "Image",
-                  }
+                  },
                 ),
               },
             }),
@@ -204,7 +204,7 @@ export default config({
                   {
                     label: "Carousel Images",
                     itemLabel: (props) => props.value?.filename || "Image",
-                  }
+                  },
                 ),
               },
             }),

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -274,7 +274,7 @@ function createHeading(level: number) {
           className: "anchor",
         }),
       ],
-      children
+      children,
     );
   };
 }

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -6,6 +6,7 @@ import React, { ComponentType, ReactNode } from "react";
 import { Banner, BannerProps } from "./ui/banner/banner";
 import { YouTubeEmbed } from "@next/third-parties/google";
 import { InViewImagesGrid } from "./ui/in-view/in-view-images-grid";
+import { ArenaCarousel } from "./ui/carousel/arena-carousel";
 import Prism from "prismjs";
 import "prismjs/themes/prism-tomorrow.css";
 import "prismjs/components/prism-javascript";
@@ -273,7 +274,7 @@ function createHeading(level: number) {
           className: "anchor",
         }),
       ],
-      children,
+      children
     );
   };
 }
@@ -313,6 +314,9 @@ const components: ComponentsType = {
   code: Code,
   Table,
   Arena,
+  ArenaCarousel: ({ channelSlug }: { channelSlug: string }) => (
+    <ArenaCarousel channelSlug={channelSlug} />
+  ),
   Youtube,
   Iframe,
   Banner: (props: BannerProps) => <Banner {...props} />,

--- a/src/components/ui/carousel/arena-carousel.tsx
+++ b/src/components/ui/carousel/arena-carousel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "./carousel";
+
+interface ArenaBlock {
+  image: {
+    display: {
+      url: string;
+    };
+  };
+}
+
+interface ArenaCarouselProps {
+  channelSlug: string;
+}
+
+function LoadingSpinner() {
+  return (
+    <div className="flex justify-center items-center h-64">
+      <div className="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-gray-900 dark:border-gray-100"></div>
+    </div>
+  );
+}
+
+export function ArenaCarousel({ channelSlug }: ArenaCarouselProps) {
+  const [images, setImages] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchImages = async () => {
+      setLoading(true);
+      try {
+        const response = await fetch(`/api/channel?slug=${channelSlug}`);
+        const data = await response.json();
+        const imageUrls = data.contents
+          .filter((block: ArenaBlock) => block.image && block.image.display)
+          .map((block: ArenaBlock) => block.image.display.url)
+          .slice(0, 5);
+        setImages(imageUrls);
+      } catch (error) {
+        console.error("Error fetching images:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchImages();
+  }, [channelSlug]);
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <Carousel className="w-full max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl mx-auto relative">
+      <CarouselContent className="h-full flex items-center">
+        {images.map((imgSrc, index) => (
+          <CarouselItem
+            key={index}
+            className="h-full flex items-center justify-center"
+          >
+            <div className="py-4 h-full flex items-center justify-center">
+              <Image
+                src={imgSrc}
+                unoptimized
+                alt={`Image from Are.na channel ${channelSlug}, index:${index}`}
+                className="max-w-full max-h-full w-auto h-auto object-contain shadow-lg grayscale"
+                width={500}
+                height={500}
+              />
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  );
+}

--- a/src/components/ui/carousel/carousel.tsx
+++ b/src/components/ui/carousel/carousel.tsx
@@ -56,14 +56,14 @@ const Carousel = React.forwardRef<
       children,
       ...props
     },
-    ref
+    ref,
   ) => {
     const [carouselRef, api] = useEmblaCarousel(
       {
         ...opts,
         axis: orientation === "horizontal" ? "x" : "y",
       },
-      plugins
+      plugins,
     );
     const [canScrollPrev, setCanScrollPrev] = React.useState(false);
     const [canScrollNext, setCanScrollNext] = React.useState(false);
@@ -95,7 +95,7 @@ const Carousel = React.forwardRef<
           scrollNext();
         }
       },
-      [scrollPrev, scrollNext]
+      [scrollPrev, scrollNext],
     );
 
     React.useEffect(() => {
@@ -146,7 +146,7 @@ const Carousel = React.forwardRef<
         </div>
       </CarouselContext.Provider>
     );
-  }
+  },
 );
 Carousel.displayName = "Carousel";
 
@@ -163,7 +163,7 @@ const CarouselContent = React.forwardRef<
         className={cn(
           "flex",
           orientation === "horizontal" ? "h-full items-center" : "flex-col",
-          className
+          className,
         )}
         {...props}
       />
@@ -187,7 +187,7 @@ const CarouselItem = React.forwardRef<
         "min-w-0 shrink-0 grow-0 basis-full",
         orientation === "horizontal" ? "px-4" : "py-4",
         "flex items-center justify-center",
-        className
+        className,
       )}
       {...props}
     />
@@ -212,7 +212,7 @@ const CarouselPrevious = React.forwardRef<
           ? "-left-12 top-1/2 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
         "hidden sm:flex",
-        className
+        className,
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
@@ -242,7 +242,7 @@ const CarouselNext = React.forwardRef<
           ? "-right-12 top-1/2 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
         "hidden sm:flex",
-        className
+        className,
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}

--- a/src/components/ui/carousel/carousel.tsx
+++ b/src/components/ui/carousel/carousel.tsx
@@ -56,14 +56,14 @@ const Carousel = React.forwardRef<
       children,
       ...props
     },
-    ref,
+    ref
   ) => {
     const [carouselRef, api] = useEmblaCarousel(
       {
         ...opts,
         axis: orientation === "horizontal" ? "x" : "y",
       },
-      plugins,
+      plugins
     );
     const [canScrollPrev, setCanScrollPrev] = React.useState(false);
     const [canScrollNext, setCanScrollNext] = React.useState(false);
@@ -95,7 +95,7 @@ const Carousel = React.forwardRef<
           scrollNext();
         }
       },
-      [scrollPrev, scrollNext],
+      [scrollPrev, scrollNext]
     );
 
     React.useEffect(() => {
@@ -146,7 +146,7 @@ const Carousel = React.forwardRef<
         </div>
       </CarouselContext.Provider>
     );
-  },
+  }
 );
 Carousel.displayName = "Carousel";
 
@@ -162,8 +162,8 @@ const CarouselContent = React.forwardRef<
         ref={ref}
         className={cn(
           "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className,
+          orientation === "horizontal" ? "h-full items-center" : "flex-col",
+          className
         )}
         {...props}
       />
@@ -185,8 +185,9 @@ const CarouselItem = React.forwardRef<
       aria-roledescription="slide"
       className={cn(
         "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
-        className,
+        orientation === "horizontal" ? "px-4" : "py-4",
+        "flex items-center justify-center",
+        className
       )}
       {...props}
     />
@@ -206,11 +207,12 @@ const CarouselPrevious = React.forwardRef<
       variant={variant}
       size={size}
       className={cn(
-        "absolute  h-8 w-8 rounded-full",
+        "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
           ? "-left-12 top-1/2 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
-        className,
+        "hidden sm:flex",
+        className
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
@@ -239,7 +241,8 @@ const CarouselNext = React.forwardRef<
         orientation === "horizontal"
           ? "-right-12 top-1/2 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
-        className,
+        "hidden sm:flex",
+        className
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}

--- a/work/artists-from-asia.mdx
+++ b/work/artists-from-asia.mdx
@@ -12,4 +12,4 @@ publishedAt: 2019-08-05
 
 [Artists from Asia](https://www.are.na/tom/artists-from-asia) is a growing list of past and present artists from Asia. Still under construction.
 
-<InViewImagesGrid channelSlug="artists-from-asia" />
+<ArenaCarousel channelSlug="artists-from-asia" />

--- a/work/imaginary-museum.mdx
+++ b/work/imaginary-museum.mdx
@@ -10,4 +10,4 @@ Inspired by Gerhard Richter's _Atlas_ project, I wanted to create a research arc
 
 This also exists at [atlas.tom.so](https://atlas.tom.so)
 
-<InViewImagesGrid channelSlug="imaginary-museum" />
+<ArenaCarousel channelSlug="imaginary-museum" />

--- a/work/performa.mdx
+++ b/work/performa.mdx
@@ -6,4 +6,4 @@ summary: A performance art archive
 
 [Performa](https://are.na/tom-y/performa) is a performance art archive conducted and hosted on are.na. It's main purpose is to serve my own research into different practitioners of performance and moving image work, but also with the intention of acting as a educational resource for others.
 
-<InViewImagesGrid channelSlug="performa" />
+<ArenaCarousel channelSlug="performa" />

--- a/work/poetics-of-space.mdx
+++ b/work/poetics-of-space.mdx
@@ -6,4 +6,4 @@ summary: An archive of architectural images and spaces
 
 [Poetics of Space](https://shadows.tom.so) is an online are.na archive of different spaces from around the world.
 
-<InViewImagesGrid channelSlug="poetics-of-space-gvdouhcpye0" />
+<ArenaCarousel channelSlug="poetics-of-space-gvdouhcpye0" />


### PR DESCRIPTION
Carousel component to load up to five images from specified channel slug.

Basic spinner animation used as placeholder while images are loaded from API.

### Changes

- New Arena carousel component
- Add MDX support
- Updates to existing MDX files to trial use of component
- Add Keystatic support