### PR TITLE
fix: big speed refactor

### DIFF
--- a/src/app/db/work.ts
+++ b/src/app/db/work.ts
@@ -75,7 +75,7 @@ export async function getPaginatedWorkPosts(page: number, postsPerPage: number):
 }> {
   const allPosts = getWorkPosts();
   const sortedPosts = allPosts.sort((a, b) =>
-    new Date(b.metadata.publishedAt).getTime() - new Date(a.metadata.publishedAt).getTime()
+    a.metadata.title.localeCompare(b.metadata.title)
   );
   
   const totalPages = Math.ceil(sortedPosts.length / postsPerPage);

--- a/src/app/db/work.ts
+++ b/src/app/db/work.ts
@@ -66,7 +66,7 @@ const getMDXData = cache((dir: string): MDXData[] => {
 });
 
 export const getWorkPosts = cache((): MDXData[] => {
-  return getMDXData(path.join(process.cwd(), "posts"));
+  return getMDXData(path.join(process.cwd(), "work"));
 });
 
 export async function getPaginatedWorkPosts(page: number, postsPerPage: number): Promise<{

--- a/src/app/db/work.ts
+++ b/src/app/db/work.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { cache } from 'react';
 
 type Metadata = {
   title: string;
@@ -7,6 +8,12 @@ type Metadata = {
   summary: string;
   image?: string;
 };
+
+interface MDXData {
+  metadata: Metadata;
+  slug: string;
+  content: string;
+}
 
 function parseFrontmatter(fileContent: string): {
   metadata: Metadata;
@@ -45,13 +52,7 @@ function readMDXFile(filePath: string): {
   return parseFrontmatter(rawContent);
 }
 
-interface MDXData {
-  metadata: Metadata;
-  slug: string;
-  content: string;
-}
-
-function getMDXData(dir: string): MDXData[] {
+const getMDXData = cache((dir: string): MDXData[] => {
   let mdxFiles = getMDXFiles(dir);
   return mdxFiles.map((file) => {
     let { metadata, content } = readMDXFile(path.join(dir, file));
@@ -62,8 +63,28 @@ function getMDXData(dir: string): MDXData[] {
       content,
     };
   });
-}
+});
 
-export function getWorkPosts(): MDXData[] {
-  return getMDXData(path.join(process.cwd(), "work"));
+export const getWorkPosts = cache((): MDXData[] => {
+  return getMDXData(path.join(process.cwd(), "posts"));
+});
+
+export async function getPaginatedWorkPosts(page: number, postsPerPage: number): Promise<{
+  posts: MDXData[];
+  totalPages: number;
+}> {
+  const allPosts = getWorkPosts();
+  const sortedPosts = allPosts.sort((a, b) =>
+    new Date(b.metadata.publishedAt).getTime() - new Date(a.metadata.publishedAt).getTime()
+  );
+  
+  const totalPages = Math.ceil(sortedPosts.length / postsPerPage);
+  const startIndex = (page - 1) * postsPerPage;
+  const endIndex = startIndex + postsPerPage;
+  const paginatedPosts = sortedPosts.slice(startIndex, endIndex);
+
+  return {
+    posts: paginatedPosts,
+    totalPages,
+  };
 }

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,65 +1,58 @@
 import Link from "next/link";
-import { getBlogPosts } from "@/app/db/blog";
-import { Separator } from "@/components/ui/separator/separator";
-import { Suspense } from "react";
+import { getPaginatedBlogPosts } from "@/app/db/blog";
+import { Separator } from "@/components/ui/separator";
 
 export const metadata = {
   title: "Writing",
   description: "Read my thoughts.",
 };
 
-function BlogList() {
-  let allBlogs = getBlogPosts();
+const POSTS_PER_PAGE = 10;
+
+async function BlogList({ page }: { page: number }) {
+  const { posts, totalPages } = await getPaginatedBlogPosts(page, POSTS_PER_PAGE);
 
   return (
     <>
-      {allBlogs
-        .sort((a, b) => {
-          if (
-            new Date(a.metadata.publishedAt) > new Date(b.metadata.publishedAt)
-          ) {
-            return -1;
-          }
-          return 1;
-        })
-        .map((post) => (
-          <Link
-            key={post.slug}
-            className="flex flex-col hover:text-blue-700 dark:hover:text-teal-200 transition-colors duration-200 space-y-1 mb-4"
-            href={`/posts/${post.slug}`}
-          >
-            <div className="w-full flex flex-col">
-              <p className="text-2xl font-medium tracking-tighter">
-                {post.metadata.title}
-              </p>
-              <p className="text-md">{post.metadata.summary}</p>
-              <p className="text-sm">{post.metadata.publishedAt}</p>
-            </div>
-          </Link>
-        ))}
+      {posts.map((post) => (
+        <Link
+          key={post.slug}
+          className="flex flex-col hover:text-blue-700 dark:hover:text-teal-200 transition-colors duration-200 space-y-1 mb-4"
+          href={`/posts/${post.slug}`}
+        >
+          <div className="w-full flex flex-col">
+            <p className="text-2xl font-medium tracking-tighter">
+              {post.metadata.title}
+            </p>
+            <p className="text-md">{post.metadata.summary}</p>
+            <p className="text-sm">{post.metadata.publishedAt}</p>
+          </div>
+        </Link>
+      ))}
+      <div className="mt-8 flex justify-between">
+        {page > 1 && (
+          <Link href={`/posts?page=${page - 1}`}>Previous</Link>
+        )}
+        {page < totalPages && (
+          <Link href={`/posts?page=${page + 1}`}>Next</Link>
+        )}
+      </div>
     </>
   );
 }
 
-export default function BlogPage() {
+export default async function BlogPage({
+  searchParams,
+}: {
+  searchParams: { page?: string };
+}) {
+  const currentPage = Number(searchParams.page) || 1;
+
   return (
     <div className="w-full">
       <h1 className="font-medium text-4xl pt-4">Writing</h1>
       <Separator className="my-4" />
-      <Suspense
-        fallback={
-          <div className="space-y-4">
-            {[...Array(5)].map((_, i) => (
-              <div key={i} className="animate-pulse">
-                <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-2"></div>
-                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2"></div>
-              </div>
-            ))}
-          </div>
-        }
-      >
-        <BlogList />
-      </Suspense>
+      <BlogList page={currentPage} />
     </div>
   );
 }

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { getPaginatedBlogPosts } from "@/app/db/blog";
-import { Separator } from "@/components/ui/separator";
 
 export const metadata = {
   title: "Writing",
@@ -51,7 +50,7 @@ export default async function BlogPage({
   return (
     <div className="w-full">
       <h1 className="font-medium text-4xl pt-4">Writing</h1>
-      <Separator className="my-4" />
+     
       <BlogList page={currentPage} />
     </div>
   );

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -28,12 +28,12 @@ async function BlogList({ page }: { page: number }) {
           </div>
         </Link>
       ))}
-      <div className="mt-8 flex justify-between">
+      <div className="my-8 flex justify-between">
         {page > 1 && (
-          <Link href={`/posts?page=${page - 1}`}>Previous</Link>
+          <Link href={`/posts?page=${page - 1}`} className="hover:text-blue-700 dark:hover:text-teal-200 transition-colors duration-200">Previous</Link>
         )}
         {page < totalPages && (
-          <Link href={`/posts?page=${page + 1}`}>Next</Link>
+          <Link href={`/posts?page=${page + 1}`} className="hover:text-blue-700 dark:hover:text-teal-200 transition-colors duration-200">Next</Link>
         )}
       </div>
     </>
@@ -49,7 +49,7 @@ export default async function BlogPage({
 
   return (
     <div className="w-full">
-      <h1 className="font-medium text-4xl pt-4">Writing</h1>
+      <h1 className="font-medium text-4xl py-4">Writing</h1>
      
       <BlogList page={currentPage} />
     </div>

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -27,12 +27,12 @@ async function WorkList({ page }: { page: number }) {
           </div>
         </Link>
       ))}
-      <div className="mt-8 flex justify-between">
+      <div className="my-8 flex justify-between">
         {page > 1 && (
-          <Link href={`/work?page=${page - 1}`}>Previous</Link>
+          <Link href={`/work?page=${page - 1}`} className="hover:text-blue-700 dark:hover:text-teal-200 transition-colors duration-200">Previous</Link>
         )}
         {page < totalPages && (
-          <Link href={`/work?page=${page + 1}`}>Next</Link>
+          <Link href={`/work?page=${page + 1}`} className="hover:text-blue-700 dark:hover:text-teal-200 transition-colors duration-200">Next</Link>
         )}
       </div>
     </>
@@ -48,7 +48,7 @@ export default async function WorkPage({
 
   return (
     <div className="w-full">
-      <h1 className="font-medium text-4xl pt-4">Work</h1>
+      <h1 className="font-medium text-4xl py-4">Work</h1>
     
       <WorkList page={currentPage} />
     </div>

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { getPaginatedWorkPosts } from "@/app/db/work";
-import { Separator } from "@/components/ui/separator";
 
 export const metadata = {
   title: "Work",
@@ -50,7 +49,7 @@ export default async function WorkPage({
   return (
     <div className="w-full">
       <h1 className="font-medium text-4xl pt-4">Work</h1>
-      <Separator className="my-4" />
+    
       <WorkList page={currentPage} />
     </div>
   );


### PR DESCRIPTION
All of the MDX file parsing and fetching was being done client side, with no pagination or proper separation of concerns. 

This was causing major performances issues, particularly on mobile devices. 

### Changes

- pagination of work and blog posts to break fetching into smaller chunks
- move fetching to be done server side
- removed Suspense boundaries for both pages as this is no longer needed
